### PR TITLE
Implements `FiberRootManager` for app loop control

### DIFF
--- a/packages/editable/src/Editor.tsx
+++ b/packages/editable/src/Editor.tsx
@@ -44,7 +44,7 @@ export type EditorStoreStateType = {
   settingsPanel: string
 }
 
-type RpcServerFunctions = {
+export type RpcServerFunctions = {
   save(patches: EditPatch | EditPatch[]): Promise<void>
   initializeComponentsWatcher(): Promise<
     { fileName: string; components: string[] }[]

--- a/packages/editable/src/component-loader/component-loader.ts
+++ b/packages/editable/src/component-loader/component-loader.ts
@@ -1,6 +1,7 @@
 import { BirpcReturn } from "birpc"
 import create from "zustand"
 import { devtools } from "zustand/middleware"
+import { RpcServerFunctions } from "../Editor"
 
 export type ComponentType = {
   name: string

--- a/packages/panels/src/index.ts
+++ b/packages/panels/src/index.ts
@@ -1,3 +1,4 @@
+import * as Stitches from "@stitches/react"
 import { styled } from "@editable-jsx/ui"
 
 export { PanelManager } from "./PanelManager"

--- a/packages/rapier/src/index.ts
+++ b/packages/rapier/src/index.ts
@@ -1,3 +1,4 @@
+import * as Stitches from "@stitches/react"
 import { styled } from "@editable-jsx/ui"
 
 export { PanelManager } from "./PanelManager"

--- a/packages/three-fiber/src/EditorRoot.tsx
+++ b/packages/three-fiber/src/EditorRoot.tsx
@@ -4,6 +4,8 @@ import { useId } from "react"
 import { editor } from "./editor"
 import { useContextBridge } from "./useContextBridge"
 
+// TODO: Fix conditional hook calls.
+
 export function EditorRoot({
   children,
   element,

--- a/packages/three-fiber/src/FiberRootManager.tsx
+++ b/packages/three-fiber/src/FiberRootManager.tsx
@@ -37,7 +37,6 @@ export function FiberRootManager({ children }: { children: React.ReactNode }) {
         editorState.gl.domElement.parentElement?.parentElement
       )
     }
-    console.log(editorState.events)
   }, [editor])
 
   return (
@@ -60,10 +59,10 @@ function LoopManager() {
 
       if (isEditorMode) {
         suspendRoot(root)
-        if (editor.editorRoot) resumeRoot(editor.editorRoot)
+        resumeRoot(editor.editorRoot!)
       } else {
         resumeRoot(root)
-        if (editor.editorRoot) suspendRoot(editor.editorRoot)
+        suspendRoot(editor.editorRoot!)
       }
     }
   }, [editor, isEditorMode])

--- a/packages/three-fiber/src/FiberRootManager.tsx
+++ b/packages/three-fiber/src/FiberRootManager.tsx
@@ -1,0 +1,112 @@
+import {
+  context,
+  RootState,
+  useFrame,
+  useStore,
+  useThree,
+  _roots
+} from "@react-three/fiber"
+import React, { useLayoutEffect, useRef, useState } from "react"
+import { useEditor } from "@editable-jsx/editable"
+import { ThreeEditor } from "./ThreeEditor"
+import { createEditorRoot, Root } from "./root/createEditorRoot"
+import { UseBoundStore } from "zustand"
+
+type PrevFrameLoop = null | "always" | "demand" | "never"
+
+export function FiberRootManager({ children }: { children: React.ReactNode }) {
+  const editor = useEditor<ThreeEditor>()
+  const [dummy] = useState(() => {
+    const el = document.createElement("div")
+    document.body.appendChild(el)
+    return el
+  })
+
+  // This guarantees the editor root is ready right away for the context provider.
+  for (const [key, root] of _roots) {
+    if (key !== editor.canvas) continue
+    const _editorRoot = createEditorRoot(dummy, root)
+    if (_editorRoot) editor.editorRoot = _editorRoot
+    editor.appRoot = root
+  }
+
+  return (
+    editor.editorRoot && (
+      <context.Provider value={editor.editorRoot.store}>
+        <LoopManager />
+        {children}
+      </context.Provider>
+    )
+  )
+}
+
+function LoopManager() {
+  const editor = useEditor<ThreeEditor>()
+  const isEditorMode = editor.useStates("editing")
+
+  const [store] = useState({
+    prevFrameloop: null as PrevFrameLoop,
+    prevElapsedTime: 0
+  })
+
+  useLayoutEffect(() => {
+    for (const [key, root] of _roots) {
+      if (key !== editor.canvas) continue
+
+      const appState = root.store.getState()
+      const editorState = editor.editorRoot!.store.getState()
+
+      if (isEditorMode) {
+        // Suspend app root
+        store.prevFrameloop = appState.frameloop
+        appState.set({
+          frameloop: "never",
+          internal: { ...appState.internal, active: false }
+        })
+        store.prevElapsedTime = appState.clock.getElapsedTime()
+        appState.clock.stop()
+        appState.setEvents({ enabled: false })
+
+        // Enable editor root
+        editorState.set({
+          frameloop: "always",
+          internal: { ...editorState.internal, active: true }
+        })
+      } else {
+        // Enable app root
+        if (store.prevFrameloop !== null) {
+          appState.set({
+            frameloop: store.prevFrameloop,
+            internal: { ...appState.internal, active: true }
+          })
+          appState.clock.start()
+          appState.clock.elapsedTime = store.prevElapsedTime
+          appState.setEvents({ enabled: true })
+        }
+
+        // Suspend editor root
+        editorState.set({
+          frameloop: "never",
+          internal: { ...editorState.internal, active: false }
+        })
+      }
+    }
+  }, [editor, isEditorMode, store])
+
+  useFrame(({ scene, gl, camera }) => {
+    gl.render(scene, camera)
+  }, 1)
+
+  return null
+}
+
+export function AppRootProvider({ children }: { children: React.ReactNode }) {
+  const editor = useEditor<ThreeEditor>()
+  return (
+    editor.appRoot && (
+      <context.Provider value={editor.appRoot.store}>
+        {children}
+      </context.Provider>
+    )
+  )
+}

--- a/packages/three-fiber/src/ThreeEditor.tsx
+++ b/packages/three-fiber/src/ThreeEditor.tsx
@@ -8,7 +8,7 @@ import { multiToggle } from "@editable-jsx/ui"
 import { useBounds, useHelper } from "@react-three/drei"
 import { Size, useStore } from "@react-three/fiber"
 import { BirpcReturn } from "birpc"
-import { FC, MutableRefObject, PropsWithChildren, useCallback } from "react"
+import { FC, PropsWithChildren, useCallback } from "react"
 import { Camera, Object3D, Raycaster, Scene } from "three"
 import { Root } from "./root/createEditorRoot"
 

--- a/packages/three-fiber/src/ThreeEditor.tsx
+++ b/packages/three-fiber/src/ThreeEditor.tsx
@@ -1,10 +1,16 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-import { EditableElement, Editor } from "@editable-jsx/editable"
+import {
+  EditableElement,
+  Editor,
+  RpcServerFunctions
+} from "@editable-jsx/editable"
 import { multiToggle } from "@editable-jsx/ui"
 import { useBounds, useHelper } from "@react-three/drei"
 import { Size, useStore } from "@react-three/fiber"
-import { FC, PropsWithChildren, useCallback } from "react"
+import { BirpcReturn } from "birpc"
+import { FC, MutableRefObject, PropsWithChildren, useCallback } from "react"
 import { Camera, Object3D, Raycaster, Scene } from "three"
+import { Root } from "./root/createEditorRoot"
 
 export class ThreeEditableElement extends EditableElement {
   object3D?: Object3D
@@ -56,6 +62,20 @@ export class ThreeEditor extends Editor {
   raycaster!: Raycaster
   bounds!: ReturnType<typeof useBounds>
 
+  canvas: HTMLCanvasElement | null
+  screenshotCanvas: HTMLCanvasElement | null
+  editorRoot: Root | null
+  appRoot: Root | null
+
+  constructor(plugins: any[], client: BirpcReturn<RpcServerFunctions>) {
+    super(plugins, client)
+
+    this.canvas = null
+    this.screenshotCanvas = null
+    this.editorRoot = null
+    this.appRoot = null
+  }
+
   findEditableElement(obj: any) {
     return obj?.__r3f?.editable
   }
@@ -86,7 +106,7 @@ export class ThreeEditor extends Editor {
                     element.editor.select(element)
                   }
                 },
-                [element]
+                [element, props]
               )
       }
     ]

--- a/packages/three-fiber/src/ThreeEditorCanvas.tsx
+++ b/packages/three-fiber/src/ThreeEditorCanvas.tsx
@@ -13,6 +13,8 @@ import { EditorPanels } from "./controls/EditorPanels"
 import { editor } from "./editor"
 import { EditorBounds } from "./EditorBounds"
 import { EditorRoot } from "./EditorRoot"
+import { AppRootProvider, FiberRootManager } from "./FiberRootManager"
+import { ThreeEditor } from "./ThreeEditor"
 import { ThreeEditorProvider } from "./ThreeEditorProvider"
 import { ThreeTunnel } from "./ThreeTunnel"
 import { ScreenshotCanvas } from "./useScreenshotStore"
@@ -59,7 +61,7 @@ export const ThreeEditorCanvas = forwardRef<HTMLCanvasElement, CanvasProps>(
 
 export const EditableCanvas = forwardRef<HTMLCanvasElement, CanvasProps>(
   function EditorCanvas(props, ref) {
-    const editor = useEditor()
+    const editor = useEditor<ThreeEditor>()
     const canvasSettings = editor.useSettings("scene", {
       shadows: {
         value: true
@@ -82,15 +84,23 @@ export const EditableCanvas = forwardRef<HTMLCanvasElement, CanvasProps>(
         }}
         {...canvasProps}
         {...canvasSettings}
+        ref={(el) => {
+          canvasProps.ref = el
+          editor.canvas = el
+        }}
       >
-        {/** drei's Bounds component to be able to focus on elements */}
-        <EditorBounds>
-          <Suspense>
-            <FiberProvider>
-              <EditorRoot element={editableElement}>{children}</EditorRoot>
-            </FiberProvider>
-          </Suspense>
-        </EditorBounds>
+        <FiberRootManager>
+          {/** drei's Bounds component to be able to focus on elements */}
+          <EditorBounds>
+            <Suspense>
+              <FiberProvider>
+                <EditorRoot element={editableElement}>
+                  <AppRootProvider>{children}</AppRootProvider>
+                </EditorRoot>
+              </FiberProvider>
+            </Suspense>
+          </EditorBounds>
+        </FiberRootManager>
 
         {/** Used by editor elements that need to live inside the R3F provider/scene */}
         <ThreeTunnel.Out />

--- a/packages/three-fiber/src/ThreeEditorCanvas.tsx
+++ b/packages/three-fiber/src/ThreeEditorCanvas.tsx
@@ -100,16 +100,16 @@ export const EditableCanvas = forwardRef<HTMLCanvasElement, CanvasProps>(
               </FiberProvider>
             </Suspense>
           </EditorBounds>
+
+          {/** Used by editor elements that need to live inside the R3F provider/scene */}
+          <ThreeTunnel.Out />
+
+          {/*
+           * Editor UI. This can be overriden by using the EditorUI.In component
+           * in your app to override the default UI.
+           */}
+          <EditorUI.Out fallback={<EditorControls />} />
         </FiberRootManager>
-
-        {/** Used by editor elements that need to live inside the R3F provider/scene */}
-        <ThreeTunnel.Out />
-
-        {/*
-         * Editor UI. This can be overriden by using the EditorUI.In component
-         * in your app to override the default UI.
-         */}
-        <EditorUI.Out fallback={<EditorControls />} />
       </FiberCanvas>
     )
   }

--- a/packages/three-fiber/src/controls/EditorControls.tsx
+++ b/packages/three-fiber/src/controls/EditorControls.tsx
@@ -1,6 +1,7 @@
 import { CommandBar, KeyboardCommands } from "@editable-jsx/commander"
 import { useEditor } from "@editable-jsx/editable"
 import { EditorCamera } from "./EditorCamera"
+import { FiberControls } from "./FiberControls"
 import { PerformanceControls } from "./PerformanceControls"
 import { SceneControls } from "./SceneControls"
 import { SelectedElementControls } from "./SelectedElementControls"
@@ -18,7 +19,8 @@ export function EditorControls() {
       <SceneControls panel="scene" />
       <CommandBar.In />
       <KeyboardCommands />
-      <PerformanceControls panel="settings" order={1} />
+      {/* <PerformanceControls panel="settings" order={1} /> */}
+      <FiberControls panel="settings" order={1} />
       {grid && <gridHelper />}
       {axes && <axesHelper />}
     </>

--- a/packages/three-fiber/src/controls/FiberControls.tsx
+++ b/packages/three-fiber/src/controls/FiberControls.tsx
@@ -9,6 +9,7 @@ import {
 } from "@react-three/fiber"
 import { folder, useControls } from "leva"
 import { StoreType } from "leva/dist/declarations/src/types"
+import { useLayoutEffect } from "react"
 import { ThreeEditor } from "../ThreeEditor"
 
 function FiberDisplay({
@@ -32,13 +33,25 @@ function FiberDisplay({
           },
           frameloop: { value: "always", disabled: true, order: -1 },
           pointer: { value: { x: 0, y: 0 }, disabled: true, order: 0 },
+          size: folder({
+            width: { value: 0, disabled: true },
+            height: { value: 0, disabled: true },
+            top: { value: 0, disabled: true },
+            left: { value: 0, disabled: true },
+            updateStyle: { value: false, disabled: true }
+          }),
+          camera: folder({
+            type: { value: "undefined", disabled: true },
+            uuid: { value: "undefined", disabled: true },
+            name: { value: "undefined", disabled: true }
+          }),
           clock: folder({
             elapsedTime: { value: 0, disabled: true }
           }),
           events: folder({
             priorityE: { label: "priority", value: 1, disabled: true },
             enabled: { value: true, disabled: true },
-            connected: { value: false, disabled: true }
+            connected: { value: "undefined", disabled: true }
           }),
           internal: folder({
             active: { value: false, disabled: true },
@@ -83,11 +96,26 @@ function syncDataWithState(data: any, state: RootState) {
   data["fiber.frameloop"].value = state.frameloop
   data["fiber.pointer"].value = { x: state.pointer.x, y: state.pointer.y }
 
+  data["fiber.size.height"].value = state.size?.height
+  data["fiber.size.width"].value = state.size?.width
+  data["fiber.size.top"].value = state.size?.top
+  data["fiber.size.left"].value = state.size?.left
+  data["fiber.size.updateStyle"].value = state.size?.updateStyle
+
+  data["fiber.camera.type"].value = state.camera?.type
+  data["fiber.camera.name"].value = state.camera?.name
+  data["fiber.camera.uuid"].value = state.camera?.uuid
+
   data["fiber.clock.elapsedTime"].value = state.clock.elapsedTime
 
   data["fiber.events.priorityE"].value = state.events.priority
   data["fiber.events.enabled"].value = state.events.enabled
-  data["fiber.events.connected"].value = state.events.connected
+  data["fiber.events.connected"].value =
+    state.events.connected === false
+      ? "false"
+      : state.events.connected === undefined
+      ? "undefined"
+      : state.events.connected.nodeName.toLowerCase()
 
   data["fiber.internal.active"].value = state.internal.active
   data["fiber.internal.priorityI"].value = state.internal.priority
@@ -105,17 +133,21 @@ function FiberMonitor({
   const editor = useEditor<ThreeEditor>()
 
   // The after effect never stops firing in v8 so we get constant updates.
-  addAfterEffect(() => {
-    if (render && !render()) return
-    const data = panel.getData() as any
-    const state =
-      data["fiber.root"].value === "appRoot"
-        ? editor.appRoot!.store.getState()
-        : editor.editorRoot!.store.getState()
+  useLayoutEffect(() => {
+    const unsub = addAfterEffect(() => {
+      if (render && !render()) return
 
-    syncDataWithState(data, state)
-    panel.setState({ data })
-  })
+      const data = panel.getData() as any
+      const state =
+        data["fiber.root"].value === "appRoot"
+          ? editor.appRoot!.store.getState()
+          : editor.editorRoot!.store.getState()
+
+      syncDataWithState(data, state)
+      panel.setState({ data })
+    })
+    return () => unsub()
+  }, [editor, panel, render])
 
   return null
 }

--- a/packages/three-fiber/src/controls/FiberControls.tsx
+++ b/packages/three-fiber/src/controls/FiberControls.tsx
@@ -96,15 +96,15 @@ function syncDataWithState(data: any, state: RootState) {
   data["fiber.frameloop"].value = state.frameloop
   data["fiber.pointer"].value = { x: state.pointer.x, y: state.pointer.y }
 
-  data["fiber.size.height"].value = state.size?.height
-  data["fiber.size.width"].value = state.size?.width
-  data["fiber.size.top"].value = state.size?.top
-  data["fiber.size.left"].value = state.size?.left
-  data["fiber.size.updateStyle"].value = state.size?.updateStyle
+  data["fiber.size.height"].value = `${state.size?.height}`
+  data["fiber.size.width"].value = `${state.size?.width}`
+  data["fiber.size.top"].value = `${state.size?.top}`
+  data["fiber.size.left"].value = `${state.size?.left}`
+  data["fiber.size.updateStyle"].value = `${state.size?.updateStyle}`
 
-  data["fiber.camera.type"].value = state.camera?.type
-  data["fiber.camera.name"].value = state.camera?.name
-  data["fiber.camera.uuid"].value = state.camera?.uuid
+  data["fiber.camera.type"].value = `${state.camera?.type}`
+  data["fiber.camera.name"].value = `${state.camera?.name}`
+  data["fiber.camera.uuid"].value = `${state.camera?.uuid}`
 
   data["fiber.clock.elapsedTime"].value = state.clock.elapsedTime
 

--- a/packages/three-fiber/src/controls/FiberControls.tsx
+++ b/packages/three-fiber/src/controls/FiberControls.tsx
@@ -1,0 +1,128 @@
+import { usePanel } from "@editable-jsx/panels"
+import { Panel } from "@editable-jsx/panels/src/PanelManager"
+import { useThree } from "@react-three/fiber"
+import { folder, useControls } from "leva"
+import { StoreType } from "leva/dist/declarations/src/types"
+import { useEffect } from "react"
+import { useFrame } from "../useFrame"
+
+function FiberDisplay({
+  panel: id = "settings",
+  order = 0,
+  render
+}: {
+  panel?: string
+  order?: number
+  render?: () => boolean
+}) {
+  const panel = usePanel(id)
+
+  useControls(
+    {
+      fiber: folder(
+        {
+          frameloop: { value: "always", disabled: true, order: 0 },
+          clock: folder({
+            elapsedTime: { value: 0, disabled: true },
+            delta: { value: 0, pad: 4, disabled: true }
+          }),
+          events: folder({
+            priorityE: { label: "priority", value: 1, disabled: true },
+            enabled: { value: true, disabled: true },
+            connected: { value: false, disabled: true }
+          }),
+          internal: folder({
+            active: { value: false, disabled: true },
+            priorityI: { label: "priority", value: 0, disabled: true },
+            frames: { value: 0, disabled: true }
+          })
+        },
+        {
+          collapsed: true,
+          order: order,
+          render
+        }
+      )
+    },
+    {
+      store: panel.store as StoreType
+    },
+    []
+  )
+
+  return null
+}
+
+export function FiberControls({
+  panel = "scene",
+  order = 0,
+  render
+}: {
+  panel?: string
+  order?: number
+  render?: () => boolean
+}) {
+  return (
+    <>
+      <FiberDisplay panel={panel} order={order} render={render} />
+      <FiberMonitor panel={panel} />
+    </>
+  )
+}
+
+function useControlEffect(
+  panel: Panel,
+  render: (() => boolean) | undefined,
+  key: string,
+  value: any
+) {
+  return useEffect(() => {
+    let data = panel.getData() as any
+    if (render && !render()) {
+      return
+    }
+
+    data[key].value = value
+
+    panel.setState({ data })
+  }, [panel, render, value, key])
+}
+
+function FiberMonitor({
+  panel: id = "scene",
+  render
+}: {
+  panel?: string
+  render?: () => boolean
+}) {
+  const panel = usePanel(id)
+
+  const frameloop = useThree((state) => state.frameloop)
+  const active = useThree((state) => state.internal.active)
+  const internalPriority = useThree((state) => state.internal.priority)
+  const eventsPriority = useThree((state) => state.events.priority)
+  const eventsEnabled = useThree((state) => state.events.enabled)
+  const eventsConnected = useThree((state) => state.events.connected)
+
+  useControlEffect(panel, render, "fiber.frameloop", frameloop)
+  useControlEffect(panel, render, "fiber.internal.active", active)
+  useControlEffect(panel, render, "fiber.internal.priorityI", internalPriority)
+  useControlEffect(panel, render, "fiber.events.priorityE", eventsPriority)
+  useControlEffect(panel, render, "fiber.events.enabled", eventsEnabled)
+  useControlEffect(panel, render, "fiber.events.connected", eventsConnected)
+
+  useFrame((state, delta) => {
+    let data = panel.getData() as any
+    if (render && !render()) {
+      return
+    }
+
+    data["fiber.clock.elapsedTime"].value = state.clock.elapsedTime
+    data["fiber.clock.delta"].value = delta
+    data["fiber.internal.frames"].value = state.internal.frames
+
+    panel.setState({ data })
+  })
+
+  return null
+}

--- a/packages/three-fiber/src/root/createEditorRoot.ts
+++ b/packages/three-fiber/src/root/createEditorRoot.ts
@@ -1,4 +1,4 @@
-import { RootState, _roots } from "@react-three/fiber"
+import { events, RootState, _roots } from "@react-three/fiber"
 import { UseBoundStore } from "zustand"
 import { createStore } from "./createEditorStore"
 
@@ -11,10 +11,17 @@ export function createEditorRoot(key: HTMLDivElement, appRoot: Root) {
   if (_roots.has(key)) return
 
   const appState = appRoot.store.getState()
-  const editorStore = createStore(appState.scene, appState.gl, appState.camera)
+  const editorStore = createStore(
+    appState.scene,
+    appState.gl,
+    appState.camera,
+    appState.size,
+    appState.viewport
+  )
 
   editorStore.getState().set((state: RootState) => ({
-    internal: { ...state.internal, active: true }
+    internal: { ...state.internal, active: true },
+    events: { ...events(editorStore), priority: appState.events.priority + 1 }
   }))
 
   const editorRoot: Root = {

--- a/packages/three-fiber/src/root/createEditorRoot.ts
+++ b/packages/three-fiber/src/root/createEditorRoot.ts
@@ -1,0 +1,28 @@
+import { RootState, _roots } from "@react-three/fiber"
+import { UseBoundStore } from "zustand"
+import { createStore } from "./createEditorStore"
+
+export type Root = {
+  fiber: any
+  store: UseBoundStore<RootState>
+}
+
+export function createEditorRoot(key: HTMLDivElement, appRoot: Root) {
+  if (_roots.has(key)) return
+
+  const appState = appRoot.store.getState()
+  const editorStore = createStore(appState.scene, appState.gl, appState.camera)
+
+  editorStore.getState().set((state: RootState) => ({
+    internal: { ...state.internal, active: true }
+  }))
+
+  const editorRoot: Root = {
+    fiber: null,
+    store: editorStore
+  }
+
+  _roots.set(key, editorRoot)
+
+  return editorRoot
+}

--- a/packages/three-fiber/src/root/createEditorstore.ts
+++ b/packages/three-fiber/src/root/createEditorstore.ts
@@ -1,0 +1,298 @@
+import {
+  Dpr,
+  EventManager,
+  RenderCallback,
+  RootState,
+  Size,
+  ThreeEvent,
+  Viewport,
+  Camera,
+  invalidate,
+  advance
+} from "@react-three/fiber"
+import create, { StoreApi, UseBoundStore } from "zustand"
+import * as THREE from "three"
+import React from "react"
+
+const isOrthographicCamera = (def: Camera): def is THREE.OrthographicCamera =>
+  def && (def as THREE.OrthographicCamera).isOrthographicCamera
+
+function calculateDpr(dpr: Dpr) {
+  const target = typeof window !== "undefined" ? window.devicePixelRatio : 1
+  return Array.isArray(dpr) ? Math.min(Math.max(dpr[0], target), dpr[1]) : dpr
+}
+
+type DomEvent = PointerEvent | MouseEvent | WheelEvent
+
+export function updateCamera(
+  camera: Camera & { manual?: boolean },
+  size: Size
+) {
+  // https://github.com/pmndrs/react-three-fiber/issues/92
+  // Do not mess with the camera if it belongs to the user
+  if (!camera.manual) {
+    if (isOrthographicCamera(camera)) {
+      camera.left = size.width / -2
+      camera.right = size.width / 2
+      camera.top = size.height / 2
+      camera.bottom = size.height / -2
+    } else {
+      camera.aspect = size.width / size.height
+    }
+    camera.updateProjectionMatrix()
+    // https://github.com/pmndrs/react-three-fiber/issues/178
+    // Update matrix world since the renderer is a frame late
+    camera.updateMatrixWorld()
+  }
+}
+
+export const createStore = (
+  sceneProp: THREE.Scene,
+  glProp: THREE.WebGLRenderer,
+  cameraProp: THREE.Camera
+) => {
+  const rootState = create<RootState>((set, get) => {
+    const position = new THREE.Vector3()
+    const defaultTarget = new THREE.Vector3()
+    const tempTarget = new THREE.Vector3()
+    function getCurrentViewport(
+      camera: Camera = get().camera,
+      target: THREE.Vector3 | Parameters<THREE.Vector3["set"]> = defaultTarget,
+      size: Size = get().size
+    ): Omit<Viewport, "dpr" | "initialDpr"> {
+      const { width, height, top, left } = size
+      const aspect = width / height
+      if (target instanceof THREE.Vector3) tempTarget.copy(target)
+      else tempTarget.set(...target)
+      const distance = camera.getWorldPosition(position).distanceTo(tempTarget)
+      if (isOrthographicCamera(camera)) {
+        return {
+          width: width / camera.zoom,
+          height: height / camera.zoom,
+          top,
+          left,
+          factor: 1,
+          distance,
+          aspect
+        }
+      } else {
+        const fov = (camera.fov * Math.PI) / 180 // convert vertical fov to radians
+        const h = 2 * Math.tan(fov / 2) * distance // visible height
+        const w = h * (width / height)
+        return {
+          width: w,
+          height: h,
+          top,
+          left,
+          factor: width / w,
+          distance,
+          aspect
+        }
+      }
+    }
+
+    let performanceTimeout: ReturnType<typeof setTimeout> | undefined =
+      undefined
+    const setPerformanceCurrent = (current: number) =>
+      set((state) => ({ performance: { ...state.performance, current } }))
+
+    const pointer = new THREE.Vector2()
+
+    const rootState: RootState = {
+      set,
+      get,
+
+      // Mock objects that have to be configured
+      gl: glProp as unknown as THREE.WebGLRenderer,
+      camera: cameraProp as unknown as Camera,
+      raycaster: null as unknown as THREE.Raycaster,
+      events: { priority: 1, enabled: true, connected: false },
+      xr: null as unknown as { connect: () => void; disconnect: () => void },
+
+      invalidate: (frames = 1) => invalidate(get(), frames),
+      advance: (timestamp: number, runGlobalEffects?: boolean) =>
+        advance(timestamp, runGlobalEffects, get()),
+
+      legacy: false,
+      linear: false,
+      flat: false,
+      scene: sceneProp,
+
+      controls: null,
+      clock: new THREE.Clock(),
+      pointer,
+      mouse: pointer,
+
+      frameloop: "always",
+      onPointerMissed: undefined,
+
+      performance: {
+        current: 1,
+        min: 0.5,
+        max: 1,
+        debounce: 200,
+        regress: () => {
+          const state = get()
+          // Clear timeout
+          if (performanceTimeout) clearTimeout(performanceTimeout)
+          // Set lower bound performance
+          if (state.performance.current !== state.performance.min)
+            setPerformanceCurrent(state.performance.min)
+          // Go back to upper bound performance after a while unless something regresses meanwhile
+          performanceTimeout = setTimeout(
+            () => setPerformanceCurrent(get().performance.max),
+            state.performance.debounce
+          )
+        }
+      },
+
+      size: { width: 0, height: 0, top: 0, left: 0, updateStyle: false },
+      viewport: {
+        initialDpr: 0,
+        dpr: 0,
+        width: 0,
+        height: 0,
+        top: 0,
+        left: 0,
+        aspect: 0,
+        distance: 0,
+        factor: 0,
+        getCurrentViewport
+      },
+
+      setEvents: (events: Partial<EventManager<any>>) =>
+        set((state) => ({ ...state, events: { ...state.events, ...events } })),
+      setSize: (
+        width: number,
+        height: number,
+        updateStyle?: boolean,
+        top?: number,
+        left?: number
+      ) => {
+        const camera = get().camera
+        const size = {
+          width,
+          height,
+          top: top || 0,
+          left: left || 0,
+          updateStyle
+        }
+        set((state) => ({
+          size,
+          viewport: {
+            ...state.viewport,
+            ...getCurrentViewport(camera, defaultTarget, size)
+          }
+        }))
+      },
+      setDpr: (dpr: Dpr) =>
+        set((state) => {
+          const resolved = calculateDpr(dpr)
+          return {
+            viewport: {
+              ...state.viewport,
+              dpr: resolved,
+              initialDpr: state.viewport.initialDpr || resolved
+            }
+          }
+        }),
+      setFrameloop: (frameloop: "always" | "demand" | "never" = "always") => {
+        const clock = get().clock
+
+        // if frameloop === "never" clock.elapsedTime is updated using advance(timestamp)
+        clock.stop()
+        clock.elapsedTime = 0
+
+        if (frameloop !== "never") {
+          clock.start()
+          clock.elapsedTime = 0
+        }
+        set(() => ({ frameloop }))
+      },
+
+      previousRoot: undefined,
+      internal: {
+        active: false,
+        priority: 0,
+        frames: 0,
+        lastEvent: React.createRef(),
+
+        interaction: [],
+        hovered: new Map<string, ThreeEvent<DomEvent>>(),
+        subscribers: [],
+        initialClick: [0, 0],
+        initialHits: [],
+        capturedMap: new Map(),
+
+        subscribe: (
+          ref: React.MutableRefObject<RenderCallback>,
+          priority: number,
+          store: UseBoundStore<any>
+        ) => {
+          const internal = get().internal
+          // If this subscription was given a priority, it takes rendering into its own hands
+          // For that reason we switch off automatic rendering and increase the manual flag
+          // As long as this flag is positive there can be no internal rendering at all
+          // because there could be multiple render subscriptions
+          internal.priority = internal.priority + (priority > 0 ? 1 : 0)
+          internal.subscribers.push({ ref, priority, store })
+          // Register subscriber and sort layers from lowest to highest, meaning,
+          // highest priority renders last (on top of the other frames)
+          internal.subscribers = internal.subscribers.sort(
+            (a, b) => a.priority - b.priority
+          )
+          return () => {
+            const internal = get().internal
+            if (internal?.subscribers) {
+              // Decrease manual flag if this subscription had a priority
+              internal.priority = internal.priority - (priority > 0 ? 1 : 0)
+              // Remove subscriber from list
+              internal.subscribers = internal.subscribers.filter(
+                (s) => s.ref !== ref
+              )
+            }
+          }
+        }
+      }
+    }
+
+    return rootState
+  })
+
+  const state = rootState.getState()
+
+  let oldSize = state.size
+  let oldDpr = state.viewport.dpr
+  let oldCamera = state.camera
+  rootState.subscribe(() => {
+    const { camera, size, viewport, gl, set } = rootState.getState()
+
+    // Resize camera and renderer on changes to size and pixelratio
+    if (size !== oldSize || viewport.dpr !== oldDpr) {
+      oldSize = size
+      oldDpr = viewport.dpr
+      // Update camera & renderer
+      updateCamera(camera, size)
+      gl.setPixelRatio(viewport.dpr)
+      gl.setSize(size.width, size.height, size.updateStyle)
+    }
+
+    // Update viewport once the camera changes
+    if (camera !== oldCamera) {
+      oldCamera = camera
+      // Update viewport
+      set((state) => ({
+        viewport: {
+          ...state.viewport,
+          ...state.viewport.getCurrentViewport(camera)
+        }
+      }))
+    }
+  })
+
+  // Invalidate on any change
+  rootState.subscribe((state) => invalidate(state))
+
+  // Return root state
+  return rootState
+}

--- a/packages/three-fiber/src/root/createEditorstore.ts
+++ b/packages/three-fiber/src/root/createEditorstore.ts
@@ -46,10 +46,20 @@ export function updateCamera(
   }
 }
 
+type ViewportState = Viewport & {
+  getCurrentViewport: (
+    camera?: Camera,
+    target?: THREE.Vector3 | Parameters<THREE.Vector3["set"]>,
+    size?: Size
+  ) => Omit<Viewport, "dpr" | "initialDpr">
+}
+
 export const createStore = (
   sceneProp: THREE.Scene,
   glProp: THREE.WebGLRenderer,
-  cameraProp: THREE.Camera
+  cameraProp: THREE.Camera,
+  sizeProp: Size,
+  viewportProp: ViewportState
 ) => {
   const rootState = create<RootState>((set, get) => {
     const position = new THREE.Vector3()
@@ -105,7 +115,8 @@ export const createStore = (
       // Mock objects that have to be configured
       gl: glProp as unknown as THREE.WebGLRenderer,
       camera: cameraProp as unknown as Camera,
-      raycaster: null as unknown as THREE.Raycaster,
+      raycaster: new THREE.Raycaster(),
+      //   raycaster: null as unknown as THREE.Raycaster,
       events: { priority: 1, enabled: true, connected: false },
       xr: null as unknown as { connect: () => void; disconnect: () => void },
 
@@ -146,19 +157,21 @@ export const createStore = (
         }
       },
 
-      size: { width: 0, height: 0, top: 0, left: 0, updateStyle: false },
-      viewport: {
-        initialDpr: 0,
-        dpr: 0,
-        width: 0,
-        height: 0,
-        top: 0,
-        left: 0,
-        aspect: 0,
-        distance: 0,
-        factor: 0,
-        getCurrentViewport
-      },
+      //   size: { width: 0, height: 0, top: 0, left: 0, updateStyle: false },
+      size: sizeProp,
+      //   viewport: {
+      //     initialDpr: 0,
+      //     dpr: 0,
+      //     width: 0,
+      //     height: 0,
+      //     top: 0,
+      //     left: 0,
+      //     aspect: 0,
+      //     distance: 0,
+      //     factor: 0,
+      //     getCurrentViewport
+      //   },
+      viewport: viewportProp,
 
       setEvents: (events: Partial<EventManager<any>>) =>
         set((state) => ({ ...state, events: { ...state.events, ...events } })),

--- a/packages/three-fiber/src/root/rootControls.ts
+++ b/packages/three-fiber/src/root/rootControls.ts
@@ -1,0 +1,45 @@
+import { Root } from "./createEditorRoot"
+
+export type PrevFrameLoop = null | "always" | "demand" | "never"
+export type RootControlState = {
+  prevFrameloop: PrevFrameLoop
+  prevElapsedTime: number
+}
+const controlStore = new Map<Root, RootControlState>()
+
+export function suspendRoot(root: Root) {
+  const rootState = root.store.getState()
+  const controlState: RootControlState = controlStore.get(root) ?? {
+    prevFrameloop: null,
+    prevElapsedTime: 0
+  }
+
+  if (!controlStore.has(root)) controlStore.set(root, controlState)
+
+  controlState.prevFrameloop = rootState.frameloop
+  rootState.set({
+    frameloop: "never",
+    internal: { ...rootState.internal, active: false }
+  })
+  controlState.prevElapsedTime = rootState.clock.getElapsedTime()
+  rootState.clock.stop()
+  rootState.setEvents({ enabled: false })
+}
+
+export function resumeRoot(root: Root) {
+  const rootState = root.store.getState()
+  const controlState: RootControlState = controlStore.get(root) ?? {
+    prevFrameloop: null,
+    prevElapsedTime: 0
+  }
+
+  if (!controlStore.has(root)) controlStore.set(root, controlState)
+
+  if (controlState.prevFrameloop !== null) {
+    rootState.set({ frameloop: controlState.prevFrameloop })
+  }
+  rootState.set({ internal: { ...rootState.internal, active: true } })
+  rootState.clock.start()
+  rootState.clock.elapsedTime = controlState.prevElapsedTime
+  rootState.setEvents({ enabled: true })
+}

--- a/packages/three-fiber/src/useScreenshotStore.tsx
+++ b/packages/three-fiber/src/useScreenshotStore.tsx
@@ -1,9 +1,10 @@
-import { EditorContext } from "@editable-jsx/editable"
+import { EditorContext, useEditor } from "@editable-jsx/editable"
 import { createStore } from "@editable-jsx/state"
 import { createMultiTunnel } from "@editable-jsx/ui"
 import { createRoot, ReconcilerRoot, _roots } from "@react-three/fiber"
 import { ReactNode, useLayoutEffect as useEffect, useRef } from "react"
 import { editor } from "./editor"
+import { ThreeEditor } from "./ThreeEditor"
 
 export const screenshotTunnel = createMultiTunnel()
 
@@ -19,13 +20,13 @@ export const useScreenshotStore = createStore<{
 }>("screenshot", (set, get) => ({
   previewId: null,
   previews: {},
-  registerPreview: (id, ref) => {
+  registerPreview: (id: string, ref: any) => {
     set((s) => {
       s.previews[id] = ref
       return { ...s }
     })
   },
-  unregisterPreview: (id) => {
+  unregisterPreview: (id: string) => {
     set((s) => {
       delete s.previews[id]
       return { ...s }
@@ -115,6 +116,8 @@ const ActiveScreenshot = () => {
 }
 export function ScreenshotCanvas() {
   const setCanvas = useScreenshotStore((s) => s.setCanvas)
+  const editor = useEditor<ThreeEditor>()
+
   return (
     <>
       <div
@@ -126,7 +129,14 @@ export function ScreenshotCanvas() {
           top: -1000
         }}
       >
-        <canvas ref={(el) => setCanvas(el!)} hidden />
+        <canvas
+          ref={(el) => {
+            if (!el) return
+            setCanvas(el)
+            editor.screenshotCanvas = el
+          }}
+          hidden
+        />
       </div>
     </>
   )

--- a/packages/ui-utils/src/HoveredIcon.ts
+++ b/packages/ui-utils/src/HoveredIcon.ts
@@ -1,3 +1,4 @@
+import * as Stitches from "@stitches/react"
 import { Icon } from "@iconify/react"
 import { styled } from "leva/plugin"
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,7 +121,7 @@ importers:
     dependencies:
       '@react-spring/core': 9.5.5_react@18.2.0
       '@react-spring/three': 9.5.5_7l5c7g5ph6e5ybhvldx3hsiylq
-      '@react-three/drei': 9.51.3_xa6xk36nauwxkzngvitxgjpnr4
+      '@react-three/drei': 9.51.6_xa6xk36nauwxkzngvitxgjpnr4
       '@react-three/editor': link:../../packages/three-fiber
       '@react-three/fiber': 8.9.1_pvdsq7s4d5knbxbfttptgjiz3a
       '@use-gesture/react': 10.2.23_react@18.2.0
@@ -5090,8 +5090,8 @@ packages:
       zustand: 3.7.2_react@18.2.0
     dev: false
 
-  /@react-three/drei/9.51.3_xa6xk36nauwxkzngvitxgjpnr4:
-    resolution: {integrity: sha512-iP6iyQj9TttnJ92x5fjunmytkK0YL33afat/F/XzFGgbyNx/R2lvKsuwSVU8YZKfXJxnoiiDdnRnUnFUKKYQlg==}
+  /@react-three/drei/9.51.6_xa6xk36nauwxkzngvitxgjpnr4:
+    resolution: {integrity: sha512-QB2/o1KN7JFhDHTPRz41d23JyJuKW/sJisvkpC4nOMKEDcp5vfSHihjKJkcA41x8RGIl435SiUMqDEIWsXCSSA==}
     peerDependencies:
       '@react-three/fiber': '>=8.0'
       react: '>=18.0'


### PR DESCRIPTION
This is a basic implementation with a `FiberRootManager` that creates an editor root and then passes its store via context to any of its children overriding the app root in R3F hooks. There is an `AppRootProvider` that passes the app store back to return normal hook behavior. Inside `FiberRootManager` is also `LoopManager` which handles all the suspend/enable logic for the different loops.

Events don't work yet.

Also adds a `FiberControl` so you can peek into some of the R3F states. Eventually, you'll be able to see them all.

Also currently extends: https://github.com/pmndrs/react-three-editor/pull/35