### PR TITLE
[WIP] stop adding _source prop if element is react fragment

### DIFF
--- a/packages/vite/src/babel/babel.ts
+++ b/packages/vite/src/babel/babel.ts
@@ -111,8 +111,9 @@ export const reactThreeEditorBabel = (api: ConfigAPI): PluginObj => {
         if (
           // the element was generated and doesn't have location information
           !node.loc ||
-          // Already has __source
-          path.node.attributes.some(isSourceAttr)
+          // Already has __source or is fragment
+          path.node.attributes.some(isSourceAttr) ||
+          isReactFragment(node)
         ) {
           return
         }
@@ -236,7 +237,6 @@ export const reactThreeEditorBabel = (api: ConfigAPI): PluginObj => {
             init: t.stringLiteral(state.filename || "")
           })
         }
-
         node.attributes.push(
           t.jsxAttribute(
             t.jsxIdentifier(TRACE_ID),
@@ -298,5 +298,18 @@ export const reactThreeEditorBabel = (api: ConfigAPI): PluginObj => {
         }
       }
     }
+  }
+}
+
+function isReactFragment(node: t.JSXOpeningElement) {
+  if (t.isJSXMemberExpression(node.name)) {
+    if (t.isJSXIdentifier(node.name.object)) {
+      return (
+        node.name.object.name === "React" &&
+        node.name.property.name === "Fragment"
+      )
+    }
+  } else if (t.isJSXIdentifier(node.name)) {
+    return node.name.name === "Fragment"
   }
 }


### PR DESCRIPTION
Hoping to resolve #38 

However changes introduced by me resulted in following error:

<img width="648" alt="Screenshot 2023-01-22 at 18 40 31" src="https://user-images.githubusercontent.com/45352717/213931135-02317c9b-13f1-4864-92e7-b8b95ce4adca.png">

Currently I have vague idea what needs to be done now - editable component tries to get display name of react fragment.
I don't know how to propagate my changes made to this package to my local vite project.
`node_modules/.vite/deps/react-three_editor_fiber.js` is the place that throws error so it should be replaced by new build but I have no clue how I can obtain new version of this file.

Could you please provide me some guidance?


